### PR TITLE
use openjdk instead of oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 script:
 - sbt "++${TRAVIS_SCALA_VERSION}!" scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test
 - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
-jdk: oraclejdk8
+jdk: openjdk8
 scala:
 - 2.13.0
 - 2.12.8


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.